### PR TITLE
feature: Add AgeSetting Management Feature

### DIFF
--- a/src/main/java/mg/noob/SkyReserve_Spring_boot/controller/AgeSettingController.java
+++ b/src/main/java/mg/noob/SkyReserve_Spring_boot/controller/AgeSettingController.java
@@ -15,21 +15,26 @@ public class AgeSettingController {
     private AgeSettingService ageSettingService;
 
     @GetMapping("/form")
-    public String showForm(@RequestParam(required = false) Long id , Model model) {
-        AgeSetting ageSetting = id != null
-                ? ageSettingService.getAgeSettingById(id).orElse(new AgeSetting())
-                : new AgeSetting();
+    public String showForm( Model model) {
+        AgeSetting ageSetting = ageSettingService.getAgeSettingById(1L).orElse(new AgeSetting());
+
         model.addAttribute("ageSetting", ageSetting);
         return "age-settings/form";
     }
 
     @PostMapping("/save")
-    public String saveAgeSetting(@ModelAttribute AgeSetting ageSetting) {
+    public String saveAgeSetting(@ModelAttribute AgeSetting ageSetting, Model model)  {
+        String message = "";
         if (ageSetting.getAgeSettingId() != null) {
             ageSettingService.updateAgeSetting(ageSetting.getAgeSettingId(), ageSetting);
+            message = "Age setting updated successfully";
         } else {
             ageSettingService.saveAgeSetting(ageSetting);
+            message = "Age setting saved successfully";
         }
-        return "redirect:/age-settings/form";
+        model.addAttribute("message", message);
+        model.addAttribute("ageSetting", ageSetting);
+        return "age-settings/form";
+
     }
 }

--- a/src/main/java/mg/noob/SkyReserve_Spring_boot/controller/AgeSettingController.java
+++ b/src/main/java/mg/noob/SkyReserve_Spring_boot/controller/AgeSettingController.java
@@ -1,0 +1,35 @@
+package mg.noob.SkyReserve_Spring_boot.controller;
+
+import mg.noob.SkyReserve_Spring_boot.model.AgeSetting;
+import mg.noob.SkyReserve_Spring_boot.service.AgeSettingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/age-settings")
+public class AgeSettingController {
+
+    @Autowired
+    private AgeSettingService ageSettingService;
+
+    @GetMapping("/form")
+    public String showForm(@RequestParam(required = false) Long id , Model model) {
+        AgeSetting ageSetting = id != null
+                ? ageSettingService.getAgeSettingById(id).orElse(new AgeSetting())
+                : new AgeSetting();
+        model.addAttribute("ageSetting", ageSetting);
+        return "age-settings/form";
+    }
+
+    @PostMapping("/save")
+    public String saveAgeSetting(@ModelAttribute AgeSetting ageSetting) {
+        if (ageSetting.getAgeSettingId() != null) {
+            ageSettingService.updateAgeSetting(ageSetting.getAgeSettingId(), ageSetting);
+        } else {
+            ageSettingService.saveAgeSetting(ageSetting);
+        }
+        return "redirect:/age-settings/form";
+    }
+}

--- a/src/main/java/mg/noob/SkyReserve_Spring_boot/model/AgeSetting.java
+++ b/src/main/java/mg/noob/SkyReserve_Spring_boot/model/AgeSetting.java
@@ -1,0 +1,26 @@
+package mg.noob.SkyReserve_Spring_boot.model;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Data
+@Entity
+@Table(name = "age_setting")
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AgeSetting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "age_setting_id")
+    private Long ageSettingId;
+
+    @Column(name = "age", nullable = false)
+    private Integer age;
+
+    @Column(name = "discount_percentage", nullable = false)
+    private Double discountPercentage;
+}

--- a/src/main/java/mg/noob/SkyReserve_Spring_boot/repository/AgeSettingRepository.java
+++ b/src/main/java/mg/noob/SkyReserve_Spring_boot/repository/AgeSettingRepository.java
@@ -1,0 +1,12 @@
+package mg.noob.SkyReserve_Spring_boot.repository;
+
+
+
+import mg.noob.SkyReserve_Spring_boot.model.AgeSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AgeSettingRepository extends JpaRepository<AgeSetting, Long> {
+
+}

--- a/src/main/java/mg/noob/SkyReserve_Spring_boot/service/AgeSettingService.java
+++ b/src/main/java/mg/noob/SkyReserve_Spring_boot/service/AgeSettingService.java
@@ -1,0 +1,41 @@
+package mg.noob.SkyReserve_Spring_boot.service;
+
+
+import mg.noob.SkyReserve_Spring_boot.model.AgeSetting;
+import mg.noob.SkyReserve_Spring_boot.repository.AgeSettingRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class AgeSettingService {
+
+    @Autowired
+    private AgeSettingRepository ageSettingRepository;
+
+    public List<AgeSetting> getAllAgeSettings() {
+        return ageSettingRepository.findAll();
+    }
+
+    public Optional<AgeSetting> getAgeSettingById(Long id) {
+        return ageSettingRepository.findById(id);
+    }
+
+    public AgeSetting saveAgeSetting(AgeSetting ageSetting) {
+        return ageSettingRepository.save(ageSetting);
+    }
+
+    public void deleteAgeSetting(Long id) {
+        ageSettingRepository.deleteById(id);
+    }
+
+    public AgeSetting updateAgeSetting(Long id, AgeSetting ageSettingDetails) {
+        AgeSetting ageSetting = ageSettingRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("AgeSetting not found for this id :: " + id));
+        ageSetting.setAge(ageSettingDetails.getAge());
+        ageSetting.setDiscountPercentage(ageSettingDetails.getDiscountPercentage());
+        return ageSettingRepository.save(ageSetting);
+    }
+}

--- a/src/main/resources/static/css/form.css
+++ b/src/main/resources/static/css/form.css
@@ -1,0 +1,40 @@
+:root[data-theme="light"] {
+    --bg-color: #ffffff;
+    --text-color: #333333;
+    --input-bg: #ffffff;
+    --input-border: #ced4da;
+}
+
+:root[data-theme="dark"] {
+    --bg-color: #212529;
+    --text-color: #ffffff;
+    --input-bg: #2b3035;
+    --input-border: #495057;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    transition: all 0.3s ease;
+}
+
+.form-control {
+    background-color: var(--input-bg);
+    border-color: var(--input-border);
+    color: var(--text-color);
+}
+
+.form-control:focus {
+    background-color: var(--input-bg);
+    border-color: #0d6efd;
+    color: var(--text-color);
+}
+
+.form-label {
+    color: var(--text-color);
+}
+
+.btn-secondary {
+    background-color: var(--input-bg);
+    border-color: var(--input-border);
+}

--- a/src/main/resources/static/js/theme.js
+++ b/src/main/resources/static/js/theme.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const themeToggle = document.getElementById('theme-toggle');
+    const icon = themeToggle.querySelector('i');
+
+    // Vérifier le thème enregistré
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    document.documentElement.setAttribute('data-theme', savedTheme);
+    updateIcon(savedTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const currentTheme = document.documentElement.getAttribute('data-theme');
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+        document.documentElement.setAttribute('data-theme', newTheme);
+        localStorage.setItem('theme', newTheme);
+        updateIcon(newTheme);
+    });
+
+    function updateIcon(theme) {
+        icon.className = theme === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+    }
+});

--- a/src/main/resources/templates/age-settings/form.html
+++ b/src/main/resources/templates/age-settings/form.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-5">
+    <h2 th:text="${ageSetting.ageSettingId} ? 'Modifier paramètre d\'âge' : 'Nouveau paramètre d\'âge'"></h2>
+
+    <form th:action="@{/age-settings/save}" th:object="${ageSetting}" method="post">
+        <input type="hidden" th:field="*{ageSettingId}">
+
+        <div class="mb-3">
+            <label for="age" class="form-label">Âge</label>
+            <input type="number" class="form-control" id="age" th:field="*{age}" required>
+        </div>
+
+        <div class="mb-3">
+            <label for="discountPercentage" class="form-label">Pourcentage de réduction</label>
+            <input type="number" class="form-control" id="discountPercentage"
+                   th:field="*{discountPercentage}" step="0.01" required>
+        </div>
+
+        <button type="submit" class="btn btn-primary">Enregistrer</button>
+        <a th:href="@{/age-settings/list}" class="btn btn-secondary">Annuler</a>
+    </form>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/age-settings/form.html
+++ b/src/main/resources/templates/age-settings/form.html
@@ -3,10 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="stylesheet" href="/css/form.css">
 </head>
 <body>
 <div class="container mt-5">
-    <h2 th:text="${ageSetting.ageSettingId} ? 'Modifier paramètre d\'âge' : 'Nouveau paramètre d\'âge'"></h2>
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2 th:text="${ageSetting.ageSettingId} ? 'Modifier paramètre d\'âge' : 'Nouveau paramètre d\'âge'"></h2>
+        <button id="theme-toggle" class="btn btn-outline-secondary">
+            <i class="fas fa-moon"></i>
+        </button>
+    </div>
 
     <form th:action="@{/age-settings/save}" th:object="${ageSetting}" method="post">
         <input type="hidden" th:field="*{ageSettingId}">
@@ -23,8 +30,9 @@
         </div>
 
         <button type="submit" class="btn btn-primary">Enregistrer</button>
-        <a th:href="@{/age-settings/list}" class="btn btn-secondary">Annuler</a>
     </form>
 </div>
+
+<script src="/js/theme.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/age-settings/form.html
+++ b/src/main/resources/templates/age-settings/form.html
@@ -9,13 +9,18 @@
 <body>
 <div class="container mt-5">
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2 th:text="${ageSetting.ageSettingId} ? 'Modifier paramètre d\'âge' : 'Nouveau paramètre d\'âge'"></h2>
+        <h2 th:text="${ageSetting.ageSettingId} ? 'Modifier paramètre d\'âge de l\'enfant' : 'Nouveau paramètre d\'âge de l\'enfant'"></h2>
         <button id="theme-toggle" class="btn btn-outline-secondary">
             <i class="fas fa-moon"></i>
         </button>
     </div>
 
     <form th:action="@{/age-settings/save}" th:object="${ageSetting}" method="post">
+
+        <div th:if="${message}" class="alert alert-success" role="alert">
+            <span th:text="${message}"></span>
+        </div>
+
         <input type="hidden" th:field="*{ageSettingId}">
 
         <div class="mb-3">


### PR DESCRIPTION
## Summary
This pull request introduces a new feature to the SkyReserve-Spring-boot project by adding functionality for managing age settings, including the creation, updating, and display of age settings through the backend and frontend. Additionally, a theme toggle feature for light/dark mode has been implemented.

## Key Changes
1. **Backend Updates**:
   - Created `AgeSetting` class, service, and repository for handling age settings.
   - Added an endpoint to save and display the age setting form.
   - Updated `AgeSettingController` to handle form submissions with appropriate messages.

2. **Frontend Updates**:
   - Added an HTML form for creating and updating age settings.
   - Enhanced `form.html` to display success and error messages for age setting operations.
   - Implemented a theme toggle functionality to switch between light and dark modes with the corresponding styles.
